### PR TITLE
Add more places for user support and help

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,16 @@ File issues to let us know what you'd like to learn. See [Contributing](#contrib
 - [Contribute to Node.js Core](http://nodetodo.org/getting-started/)
 - [Contribute to Node.js (but not sure how to get to the working group you want to help?)](https://github.com/nodejs/getting-started/blob/master/contribute_to_node.md)
 
-
-### Help
-If you're looking for help while writing Node.js, ask questions in the Node.js [Help](https://github.com/nodejs/help#-help) repository. No question is too small!
-
+ ## Support
+ If you're looking for help while writing Node.js, ask questions in the Node.js [Help](https://github.com/nodejs/help#-help) repository. No question is too small!
+ 
+ When looking for help, search for your question in these venues:
+ 
+ * [Node.js Website][https://nodejs.org]
+ * [Node.js Help][https://github.com/nodejs/help]
+ * [Open or closed issues in the related Node.js GitHub organization repository](https://github.com/nodejs)
+ * [Questions tagged 'node.js' on StackOverflow][https://stackoverflow.com/questions/tagged/node.js]
+ * [Node.js Slack Community](http://node-js.slack.com): Visit [nodeslackers.io](http://www.nodeslackers.com/) to register 
 
 ### Contributing
 *Want to write a document?*

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ File issues to let us know what you'd like to learn. See [Contributing](#contrib
 - [Contribute to Node.js Core](http://nodetodo.org/getting-started/)
 - [Contribute to Node.js (but not sure how to get to the working group you want to help?)](https://github.com/nodejs/getting-started/blob/master/contribute_to_node.md)
 
- ## Support
+ ## Help
  If you're looking for help while writing Node.js, ask questions in the Node.js [Help](https://github.com/nodejs/help#-help) repository. No question is too small!
  
  When looking for help, search for your question in these venues:

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ File issues to let us know what you'd like to learn. See [Contributing](#contrib
  
  When looking for help, search for your question in these venues:
  
- * [Node.js Website][https://nodejs.org]
- * [Node.js Help][https://github.com/nodejs/help]
+ * [Node.js Website](https://nodejs.org)
+ * [Node.js Help](https://github.com/nodejs/help)
  * [Open or closed issues in the related Node.js GitHub organization repository](https://github.com/nodejs)
- * [Questions tagged 'node.js' on StackOverflow][https://stackoverflow.com/questions/tagged/node.js]
- * [Node.js Slack Community](http://node-js.slack.com): Visit [nodeslackers.io](http://www.nodeslackers.com/) to register 
+ * [Questions tagged 'node.js' on StackOverflow](https://stackoverflow.com/questions/tagged/node.js)
+ * [Node.js Slack Community](http://node-js.slack.com): Visit [nodeslackers.com](http://www.nodeslackers.com/) to register 
 
 ### Contributing
 *Want to write a document?*


### PR DESCRIPTION
This expands help options documented in this repo for those getting started in the project. It is very similar to the nodejs/node repo but modified to cover more than just that repo. It also includes the new collaboration with the Node.js Slack Community.